### PR TITLE
commit: support git config format.pretty fuller

### DIFF
--- a/commit.js
+++ b/commit.js
@@ -94,7 +94,7 @@ Commit.prototype.parse = function parse() {
     if (matches) {
       const key = matches[1].toLowerCase()
       const val = matches[3]
-      if (key === 'date') {
+      if (key === 'date' || key === 'authordate') {
         this.date = val
       } else if (key === 'author') {
         this.author = val

--- a/test.js
+++ b/test.js
@@ -4,8 +4,10 @@ const test = require('tap').test
 const Commit = require('./commit')
 
 const str = `commit e7c077c610afa371430180fbd447bfef60ebc5ea
-Author: Calvin Metcalf <cmetcalf@appgeo.com>
-Date:   Tue Apr 12 15:42:23 2016 -0400
+Author:     Calvin Metcalf <cmetcalf@appgeo.com>
+AuthorDate: Tue Apr 12 15:42:23 2016 -0400
+Commit:     James M Snell <jasnell@gmail.com>
+CommitDate: Wed Apr 20 13:28:35 2016 -0700
 
     stream: make null an invalid chunk to write in object mode
 


### PR DESCRIPTION
Git log can be invoked with `git log --format=fuller` or `git log --pretty=fuller`. This can be set as default with `git config format.pretty fuller`.

`core-validate-commit` currently fails with `EMISSINGDATE` when this is set, this PR adds support and changes one of the tests to that format.