### PR TITLE
Don't throw an error if the user's git config uses a custom format

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -46,7 +46,7 @@ function load(sha, cb) {
     return loadPatch(parsed, cb)
   }
 
-  exec(`git show --quiet ${sha}`, (err, stdout, stderr) => {
+  exec(`git show --quiet --format=medium ${sha}`, (err, stdout, stderr) => {
     if (err) return cb(err)
     cb(null, stdout.trim())
   })


### PR DESCRIPTION
Fixes: #4

Possibly related: #1

This ensures that `git show` always returns results in the same format, rather than depending on the user's .gitconfig.

I didn't see any tests for the interface with git, but let me know if there's a place I should add some.